### PR TITLE
Update to PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
-  - hhvm
 
 before_script:
   - "composer self-update"

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,12 @@
     "description": "Provides Brazilian States",
     "type": "library",
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.0",
         "symfony/console": "^3.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.6",
-        "phpunit/phpunit": "^5.5",
+        "phpunit/phpunit": "^6.4",
         "scrutinizer/ocular": "^1.3"
     },
     "license": "MIT",

--- a/tests/Console/Commands/GenerateState/ReaderDatasetTest.php
+++ b/tests/Console/Commands/GenerateState/ReaderDatasetTest.php
@@ -3,8 +3,9 @@
 namespace Brazanation\States\Tests\Console\Commands\Generate;
 
 use Brazanation\States\Console\Commands\Generate\ReaderDataset;
+use PHPUnit\Framework\TestCase;
 
-class ReaderDatasetTest extends \PHPUnit_Framework_TestCase
+class ReaderDatasetTest extends TestCase
 {
     public function testShouldReadDatasetFile()
     {

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -3,8 +3,9 @@
 namespace Brazanation\States\Tests;
 
 use Brazanation\States;
+use PHPUnit\Framework\TestCase;
 
-class StateTest extends \PHPUnit_Framework_TestCase
+class StateTest extends TestCase
 {
     /**
      * @dataProvider provideStates


### PR DESCRIPTION
For a future release of this package, I've already updated the PHPUnit for `^6.4`.

Dropped support to `PHP 5.6` and `HHVM`, as PHPUnit 6.0 [requires PHP 7.0](https://github.com/sebastianbergmann/phpunit/blob/master/composer.json#L25).