### PR TITLE
Test enhancement

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,8 +2,6 @@ preset: PSR2
 
 risky: false
 
-linting: true
-
 enabled:
     - no_extra_consecutive_blank_lines
     - no_unused_imports

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 before_script:
   - "composer self-update"

--- a/tests/Console/Commands/GenerateState/ReaderDatasetTest.php
+++ b/tests/Console/Commands/GenerateState/ReaderDatasetTest.php
@@ -14,4 +14,24 @@ class ReaderDatasetTest extends TestCase
 
         $this->assertCount(27, $reader);
     }
+
+    public function testConstructorOnNullFilePath()
+    {
+        $reader = new ReaderDataset(null);
+        $reader->read();
+
+        $this->assertCount(27, $reader);
+    }
+
+    public function testGetCurrentStates()
+    {
+        $reader = new ReaderDataset(null);
+        $reader->read();
+        $result = $reader->current();
+
+        $this->assertSame('EstadoDo', $result->getClassName());
+        $this->assertSame('Estado do', $result->getFullName());
+        $this->assertSame('AC', $result->getShortName());
+        $this->assertSame('State', $result->getTimeZone());
+    }
 }

--- a/tests/StateTest.php
+++ b/tests/StateTest.php
@@ -20,6 +20,7 @@ class StateTest extends TestCase
         $this->assertEquals($shortName, $state->shortName, "Failed asserting short for {$fullName}");
         $this->assertEquals($code, $state->code, "Failed asserting code for {$fullName}");
         $this->assertEquals($timezone, $state->timeZone, "Failed asserting timezone for {$fullName}");
+        $this->assertTrue($state->equalTo($state));
     }
 
     public function provideStates()


### PR DESCRIPTION
# Changed log
- Set the nightly test and accept this can be failed in Travis CI build.
- Add the ```php-7.2``` test in Travis CI build.
- Add more tests.
- Remove the ```linting``` setting in ```.styleci.yml``` because the linting setting seems to be unavailable.